### PR TITLE
feat: add English translations for achievements

### DIFF
--- a/js/adventure/game.js
+++ b/js/adventure/game.js
@@ -284,7 +284,10 @@
     if (result.bonusToast) showToast(result.bonusToast);
     if (result.newAchievements) {
       result.newAchievements.forEach(ach => {
-        showToast(`🏆 ¡Logro desbloqueado: ${ach.title}!`);
+        const lang = window.getLanguage ? window.getLanguage() : 'es';
+        const translated = window.translateAchievement ? window.translateAchievement(ach, lang) : ach;
+        const msg = lang === 'en' ? 'Achievement unlocked' : '¡Logro desbloqueado';
+        showToast(`🏆 ${msg}: ${translated.title}!`);
       });
     }
     

--- a/js/deprecated/main_old.js
+++ b/js/deprecated/main_old.js
@@ -5,6 +5,15 @@ import { initVS, createMatch, joinMatch, answer, setVSName, leaveMatch } from '.
 import { trackEvent } from './stats.js';
 import { initAuth, getCurrentUser, isAuthenticated, updateUserStats, syncPendingStats, signOut } from './auth.js';
 import { createAuthModal, showAuthModal, updateUIForUser, showConvertGuestPrompt, requireAuth } from './auth_ui.js';
+import { getLanguage } from '../core/i18n.js';
+import { translateAchievement } from '../player/achievements.js';
+
+function showAchievementToast(ach) {
+  const lang = getLanguage();
+  const { title } = translateAchievement(ach, lang);
+  const msg = lang === 'en' ? 'Achievement unlocked' : '¡Logro desbloqueado';
+  toast(`🏆 ${msg}: ${title}!`);
+}
 
 /* ===== Supabase UMD ===== */
 async function getSupabaseClient(){
@@ -107,7 +116,7 @@ function renderVSQuestion(q){
     updatePlayerXPBar();
     if(results.leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
     if(results.bonusToast) toast(results.bonusToast);
-    results.newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    results.newAchievements.forEach(ach => showAchievementToast(ach));
 
     document.querySelectorAll('#options .option').forEach(el=>el.classList.add('disabled'));
     try{ answer(i); }catch(e){ console.error(e); }
@@ -147,7 +156,7 @@ async function showResults({scores, mePid}){
   updatePlayerXPBar();
   if(results.leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
   if(results.bonusToast) toast(results.bonusToast);
-  results.newAchievements.forEach(ach => setTimeout(() => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`), 500));
+results.newAchievements.forEach(ach => setTimeout(() => showAchievementToast(ach), 500));
 
   const heroTitle = fs.querySelector('.hero .big-title');
   const subtitle  = fs.querySelector('.hero .subtitle');
@@ -363,7 +372,7 @@ window.addEventListener('load', async ()=>{
     const { newAchievements, leveledUp } = await trackEvent('game_start');
     updatePlayerXPBar();
     if(leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
-    newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    newAchievements.forEach(ach => showAchievementToast(ach));
     
     vsQNo = 0; vsQTotal = null; vsActive = true;
     setVSName(document.getElementById('playerName')?.value || '');
@@ -381,7 +390,7 @@ window.addEventListener('load', async ()=>{
     const { newAchievements, leveledUp } = await trackEvent('game_start');
     updatePlayerXPBar();
     if(leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
-    newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    newAchievements.forEach(ach => showAchievementToast(ach));
 
     vsQNo = 0; vsQTotal = null; vsActive = true;
     setVSName(document.getElementById('playerName')?.value || '');

--- a/js/game/solo.js
+++ b/js/game/solo.js
@@ -3,10 +3,18 @@ import { SETTINGS, STATE } from '../deprecated/store.js';
 import { buildDeckSingle, ensureInitial60 } from './bank.js';
 import { trackEvent } from '../player/stats.js';
 import { toast, updatePlayerXPBar } from './ui.js';
-import { t } from '../core/i18n.js';
+import { t, getLanguage } from '../core/i18n.js';
+import { translateAchievement } from '../player/achievements.js';
 
 let audioCtx = null;
 let audioInitialized = false;
+
+function showAchievementToast(ach) {
+  const lang = getLanguage();
+  const { title } = translateAchievement(ach, lang);
+  const msg = lang === 'en' ? 'Achievement unlocked' : '¡Logro desbloqueado';
+  toast(`🏆 ${msg}: ${title}!`);
+}
 
 function ensureAC() {
   if (!SETTINGS.sounds) return null;
@@ -246,7 +254,7 @@ function renderQuestion(q){
       updatePlayerXPBar();
       if(results.leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
       if(results.bonusToast) toast(results.bonusToast);
-      results.newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+      results.newAchievements.forEach(ach => showAchievementToast(ach));
 
       if (STATE.mode==='timed' || SETTINGS.autoNextRounds) {
         setTimeout(()=> nextQuestion(), 800);
@@ -336,7 +344,7 @@ export async function endGame(){
   updatePlayerXPBar();
   if(results.leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
   if(results.bonusToast) toast(results.bonusToast);
-  results.newAchievements.forEach(ach => setTimeout(() => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`), 500));
+results.newAchievements.forEach(ach => setTimeout(() => showAchievementToast(ach), 500));
 
   showGame(false);
 }
@@ -365,7 +373,7 @@ export async function startSolo(){
   const { newAchievements, leveledUp } = await trackEvent('game_start');
   updatePlayerXPBar();
   if(leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
-  newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+newAchievements.forEach(ach => showAchievementToast(ach));
   
   STATE.score = 0;
   STATE.index = 0;

--- a/js/game/ui.js
+++ b/js/game/ui.js
@@ -2,7 +2,7 @@ import { SETTINGS } from '../deprecated/store.js';
 import { getBank, getBankCount, warmLocalBank, BASE_LABELS } from './bank.js';
 import { getStats, getUnlockedAchievements } from '../player/stats.js';
 import { getLevelProgress } from '../player/experience.js';
-import { ACHIEVEMENTS_LIST } from '../player/achievements.js';
+import { ACHIEVEMENTS_LIST, translateAchievement } from '../player/achievements.js';
 import { t, setLanguage, getLanguage, initI18n, updateUI as updateI18nUI } from '../core/i18n.js';
 
 export function updateBankCount(){
@@ -514,18 +514,19 @@ export function renderStatsPage() {
     achievementsContainer.innerHTML = `
         <div class="achievements-grid-icons">
             ${ACHIEVEMENTS_LIST.map(ach => {
+                const { title, description } = translateAchievement(ach, getLanguage());
                 const isUnlocked = unlocked.has(ach.id);
                 const iconPath = ach.icon ? `Icons/${ach.icon}` : '';
                 return `
-                    <div class="achievement-icon-item ${isUnlocked ? 'unlocked' : 'locked'}" title="${ach.description}">
+                    <div class="achievement-icon-item ${isUnlocked ? 'unlocked' : 'locked'}" title="${description}">
                         <div class="achievement-icon-wrapper">
-                            ${iconPath ? 
-                                `<img src="${iconPath}" alt="${ach.title}" onerror="this.style.display='none'; this.parentElement.innerHTML='${isUnlocked ? '🏆' : '🔒'}';" />` : 
+                            ${iconPath ?
+                                `<img src="${iconPath}" alt="${title}" onerror="this.style.display='none'; this.parentElement.innerHTML='${isUnlocked ? '🏆' : '🔒'}';" />` :
                                 (isUnlocked ? '🏆' : '🔒')
                             }
                         </div>
-                        <div class="achievement-icon-name">${ach.title}</div>
-                        <div class="achievement-tooltip">${ach.description}</div>
+                        <div class="achievement-icon-name">${title}</div>
+                        <div class="achievement-tooltip">${description}</div>
                     </div>
                 `;
             }).join('')}

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,18 @@ import { injectSimpleAuthStyles, showSimpleAuthModal } from './auth/modal.js';
 import { injectNicknameModalStyles, checkAndShowNicknameModal } from './auth/nickname_modal.js';
 import { initFriendsSystem } from './player/social.js';
 import { initFriendsSystem as initFriendsUI } from './player/friends_ui.js';
+import { getLanguage } from './core/i18n.js';
+import { translateAchievement } from './player/achievements.js';
+
+window.getLanguage = getLanguage;
+window.translateAchievement = translateAchievement;
+
+function showAchievementToast(ach) {
+  const lang = getLanguage();
+  const { title } = translateAchievement(ach, lang);
+  const msg = lang === 'en' ? 'Achievement unlocked' : '¡Logro desbloqueado';
+  toast(`🏆 ${msg}: ${title}!`);
+}
 
 /* ===== Supabase UMD ===== */
 async function getSupabaseClient(){
@@ -151,7 +163,7 @@ function renderVSQuestion(q){
       playSound('levelUp');
     }
     if(results.bonusToast) toast(results.bonusToast);
-    results.newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    results.newAchievements.forEach(ach => showAchievementToast(ach));
 
     document.querySelectorAll('#options .option').forEach(el=>el.classList.add('disabled'));
     try{ answer(i); }catch(e){ console.error(e); }
@@ -248,7 +260,7 @@ async function showResults({scores, mePid}){
     showConfetti();
   }
   if(results.bonusToast) toast(results.bonusToast);
-  results.newAchievements.forEach(ach => setTimeout(() => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`), 500));
+results.newAchievements.forEach(ach => setTimeout(() => showAchievementToast(ach), 500));
 
   const heroTitle = fs.querySelector('.hero .big-title');
   const subtitle  = fs.querySelector('.hero .subtitle');
@@ -790,7 +802,7 @@ window.addEventListener('load', async ()=>{
     const { newAchievements, leveledUp } = await trackEvent('game_start');
     updatePlayerXPBar();
     if(leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
-    newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    newAchievements.forEach(ach => showAchievementToast(ach));
     
     vsQNo = 0; vsQTotal = null; vsActive = true;
     setVSName(getPlayerNameForGame());
@@ -865,7 +877,7 @@ window.addEventListener('load', async ()=>{
     const { newAchievements, leveledUp } = await trackEvent('game_start');
     updatePlayerXPBar();
     if(leveledUp) toast("🎉 ¡Subiste de Nivel! 🎉");
-    newAchievements.forEach(ach => toast(`🏆 ¡Logro desbloqueado: ${ach.title}!`));
+    newAchievements.forEach(ach => showAchievementToast(ach));
 
     vsQNo = 0; vsQTotal = null; vsActive = true;
     setVSName(getPlayerNameForGame());

--- a/js/player/achievements.js
+++ b/js/player/achievements.js
@@ -364,3 +364,61 @@ export const ACHIEVEMENTS_LIST = [
     },
   }
 ];
+const ACHIEVEMENT_TEXT_EN = {
+  ACCURACY_STREAK_10: { title: 'Sharpshooter', description: 'Get 10 correct answers in a row.' },
+  ACCURACY_STREAK_25: { title: 'Eagle Eye', description: 'Get 25 correct answers in a row.' },
+  PERFECT_GAME: { title: 'Perfectionist', description: 'Finish a game of 15+ questions without a mistake.' },
+  KNOWLEDGE_MOVIES: { title: 'Movie Buff', description: '50 correct answers in Movies.' },
+  KNOWLEDGE_GEOGRAPHY: { title: 'Geographer', description: '50 correct answers in Geography.' },
+  KNOWLEDGE_HISTORY: { title: 'Historian', description: '50 correct answers in History.' },
+  KNOWLEDGE_SCIENCE: { title: 'Scientist', description: '50 correct answers in Science.' },
+  KNOWLEDGE_SPORTS: { title: 'Sports Fan', description: '50 correct answers in Sports.' },
+  KNOWLEDGE_SAGE: { title: 'Sage', description: '100 correct answers in EACH category.' },
+  DEDICATION_FIRST_GAME: { title: 'Beginner', description: 'Play your first game.' },
+  DEDICATION_7_DAYS: { title: 'Regular', description: 'Play 7 days in a row.' },
+  DEDICATION_30_DAYS: { title: 'Veteran', description: 'Play 30 days in a row.' },
+  DEDICATION_100_GAMES: { title: 'Legend', description: 'Play 100 games.' },
+  DEDICATION_500_GAMES: { title: 'Mythic', description: 'Play 500 games.' },
+  SPECIAL_EARLY_BIRD: { title: 'Early Bird', description: 'Play a game between 5 and 7 AM.' },
+  SPECIAL_NIGHT_OWL: { title: 'Night Owl', description: 'Play a game between 12 and 3 AM.' },
+  PRECISION_100_TOTAL: { title: 'Bright Mind', description: 'Answer 100 questions correctly in total.' },
+  PRECISION_95_PERCENT: { title: 'Master of Knowledge', description: 'Reach 95% accuracy with at least 50 questions.' },
+  PERFECT_GAMES_3: { title: 'Flawless', description: 'Complete 3 perfect games.' },
+  STREAK_50: { title: 'Unstoppable', description: 'Get a streak of 50 correct answers.' },
+  STREAK_100: { title: 'Living Legend', description: 'Get a streak of 100 correct answers.' },
+  COMEBACK_STREAK: { title: 'Comeback Kid', description: 'Get 10 correct answers in a row after 3 mistakes.' },
+  SPEED_DEMON: { title: 'Speed Demon', description: 'Answer correctly in under 3 seconds (10 times).' },
+  TIMED_HIGH_SCORE: { title: 'Ninja Reflexes', description: 'Finish a timed game with 30+ points.' },
+  TIMED_WINS_5: { title: 'Time Machine', description: 'Win 5 timed games.' },
+  VS_FIRST_WIN: { title: 'First Victory', description: 'Win your first VS match.' },
+  VS_WINS_10: { title: 'Champion', description: 'Win 10 VS matches.' },
+  VS_STREAK_5: { title: 'Invincible', description: 'Win 5 VS matches in a row.' },
+  LEVEL_5: { title: 'Promising Rookie', description: 'Reach level 5.' },
+  LEVEL_25: { title: 'Veteran', description: 'Reach level 25.' },
+  LEVEL_50: { title: 'Elite', description: 'Reach level 50.' },
+  LEVEL_100: { title: 'Legend', description: 'Reach level 100.' },
+  POLYGLOT: { title: 'Polyglot', description: 'Play in 2 different languages.' },
+  COLLECTOR_5_PACKS: { title: 'Collector', description: 'Unlock 5 question packs.' },
+  EXPLORER_ALL_CATEGORIES: { title: 'Explorer', description: 'Play all base categories.' },
+  FIRST_FRIEND: { title: 'Sociable', description: 'Add your first friend.' },
+  FRIENDS_10: { title: 'Popular', description: 'Have 10 friends in your list.' },
+  NIGHT_PLAYER: { title: 'Wise Owl', description: 'Play 10 games between 10 PM and 2 AM.' },
+  WEEKEND_WARRIOR: { title: 'Weekend Warrior', description: 'Play 20 games on weekends.' },
+  DAILY_PLAYER_14: { title: 'Healthy Addict', description: 'Play at least once a day for 14 days.' },
+  MONTHLY_MASTER: { title: 'Monthly Master', description: 'Play every day of a month.' },
+  QUESTIONS_1000: { title: 'Millennial', description: 'Answer 1000 questions in total.' },
+  CORRECT_500: { title: 'Living Encyclopedia', description: 'Answer 500 questions correctly.' },
+  ALL_ACHIEVEMENTS: { title: 'God of Knowledge', description: 'Unlock all other achievements.' }
+};
+
+export function translateAchievement(ach, lang = 'es') {
+  if (lang === 'en' && ACHIEVEMENT_TEXT_EN[ach.id]) {
+    return ACHIEVEMENT_TEXT_EN[ach.id];
+  }
+  return { title: ach.title, description: ach.description };
+}
+
+if (typeof window !== 'undefined') {
+  window.translateAchievement = translateAchievement;
+}
+

--- a/js/player/friends_ui.js
+++ b/js/player/friends_ui.js
@@ -1,5 +1,8 @@
 // js/friends_ui.js - Interfaz de usuario para el sistema de amigos
 
+import { getLanguage } from '../core/i18n.js';
+import { translateAchievement } from './achievements.js';
+
 let socialManager = null;
 let currentUserNickname = '';
 
@@ -1317,18 +1320,19 @@ async function showFriendProfile(friendId) {
     const achievementsContainer = document.getElementById('friendAchievements');
     if (achievementsContainer) {
       achievementsContainer.innerHTML = ACHIEVEMENTS_LIST.map(ach => {
+        const { title, description } = translateAchievement(ach, getLanguage());
         const isUnlocked = unlockedAchievements.has(ach.id);
         const iconPath = ach.icon ? `Icons/${ach.icon}` : '';
         return `
           <div class="achievement-icon-item ${isUnlocked ? 'unlocked' : 'locked'}">
-            <div class="achievement-tooltip">${ach.description}</div>
+            <div class="achievement-tooltip">${description}</div>
             <div class="achievement-icon-wrapper">
-              ${iconPath ? 
-                `<img src="${iconPath}" alt="${ach.title}" onerror="this.style.display='none'; this.parentElement.innerHTML='${isUnlocked ? '🏆' : '🔒'}';" />` : 
+              ${iconPath ?
+                `<img src="${iconPath}" alt="${title}" onerror="this.style.display='none'; this.parentElement.innerHTML='${isUnlocked ? '🏆' : '🔒'}';" />` :
                 (isUnlocked ? '🏆' : '🔒')
               }
             </div>
-            <div class="achievement-icon-name">${ach.title}</div>
+            <div class="achievement-icon-name">${title}</div>
           </div>
         `;
       }).join('');


### PR DESCRIPTION
## Summary
- translate achievements to English and expose helper for localization
- update UI and toast messages to use translated achievement titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bb136c84833080d47d1e5b95bd62